### PR TITLE
Refactor manifest

### DIFF
--- a/lib/stemcell/builder.rb
+++ b/lib/stemcell/builder.rb
@@ -51,9 +51,9 @@ module Bosh::Agent::StemCell
     #    :architecture => @architecture
     #  }
     #}
-    def initialize(opts={}, manifest={})
+    def initialize(opts)
       initialize_instance_vars(opts)
-      initialize_manifest(manifest)
+      initialize_manifest
 
       sanity_check
     end
@@ -198,19 +198,18 @@ private
 
     # Merges the given manifest with the default values and assign it to the @manifest instance variable which is later
     # used to generate the stemcell.MF ( the stemcell manifest) that is put in the generated stemcell archive.
-    def initialize_manifest(manifest={})
+    def initialize_manifest
       # perform a deep_merge of the provided manifest with the defaults
-      @manifest = manifest.deep_merge(
-        {
-          :name => @name,
-          :version => @agent_version,
-          :bosh_protocol => @bosh_protocol,
-          :cloud_properties => {
-            :infrastructure => @infrastructure,
-            :architecture => @architecture
-          }
+      @manifest = {
+        :name => @name,
+        :version => @agent_version,
+        :bosh_protocol => @bosh_protocol,
+        :cloud_properties => {
+          :root_device_name => DEFAULT_DEVICE_NAME,
+          :infrastructure => @infrastructure,
+          :architecture => @architecture
         }
-      )
+      }
     end
 
     def sanity_check

--- a/lib/stemcell/builder.rb
+++ b/lib/stemcell/builder.rb
@@ -20,7 +20,6 @@ module Bosh::Agent::StemCell
     attr_accessor :prefix, :target
     attr_accessor :iso, :iso_md5, :iso_filename
     attr_accessor :logger
-    attr_accessor :manifest
 
     # Stemcell builders are initialized with a manifest and a set of options. The options provided are merged with the
     # defaults to allow the end user/developer to specify only the ones that they wish to change and fallback to the defaults.
@@ -52,8 +51,26 @@ module Bosh::Agent::StemCell
     #  }
     #}
     def initialize(opts)
-      initialize_instance_vars(opts)
-      initialize_manifest
+      @logger = opts[:logger] || Logger.new(STDOUT)
+      @name = opts[:name] || DEFAULT_STEMCELL_NAME
+      @prefix = opts[:prefix] || Dir.pwd
+      @infrastructure = opts[:infrastructure] || DEFAULT_INFRASTRUCTURE
+      @architecture = opts[:architecture] || DEFAULT_ARCHITECTURE
+      @agent_version = Bosh::Agent::VERSION
+      @bosh_protocol = Bosh::Agent::BOSH_PROTOCOL
+      @agent_src_path = opts[:agent_src_path] || "./bosh_agent-#{agent_version}.gem"
+      @target ||= File.join(@prefix, "bosh-#{type}-#{@agent_version}.tgz")
+      @iso = opts[:iso]
+      @iso_md5 = opts[:iso_md5]
+
+      if @iso
+        unless @iso_md5
+          raise "MD5 must be specified is ISO is specified"
+        end
+        @iso_filename ||= File.basename @iso
+      else
+        init_default_iso
+      end
 
       sanity_check
     end
@@ -105,7 +122,7 @@ module Bosh::Agent::StemCell
     def generate_manifest
       stemcell_mf_path = File.expand_path "stemcell.MF", @prefix
       File.open(stemcell_mf_path, "w") do |f|
-        f.write(@manifest.to_yaml)
+        f.write(manifest.to_yaml)
       end
     end
 
@@ -130,6 +147,19 @@ module Bosh::Agent::StemCell
       setup
       build_vm
       package_stemcell
+    end
+
+    def manifest
+      @manifest ||= {
+        :name => @name,
+        :version => @agent_version,
+        :bosh_protocol => @bosh_protocol,
+        :cloud_properties => {
+          :root_device_name => DEFAULT_DEVICE_NAME,
+          :infrastructure => @infrastructure,
+          :architecture => @architecture
+        }
+      }
     end
 
     protected
@@ -171,46 +201,6 @@ module Bosh::Agent::StemCell
     end
 
 private
-
-    # Initialize all the options passed to the builder as instance variables after merging with the default values.
-    def initialize_instance_vars(opts)
-      @logger = opts[:logger] || Logger.new(STDOUT)
-      @name = opts[:name] || DEFAULT_STEMCELL_NAME
-      @prefix = opts[:prefix] || Dir.pwd
-      @infrastructure = opts[:infrastructure] || DEFAULT_INFRASTRUCTURE
-      @architecture = opts[:architecture] || DEFAULT_ARCHITECTURE
-      @agent_version = Bosh::Agent::VERSION
-      @bosh_protocol = Bosh::Agent::BOSH_PROTOCOL
-      @agent_src_path = opts[:agent_src_path] || "./bosh_agent-#{agent_version}.gem"
-      @target ||= File.join(@prefix, "bosh-#{type}-#{@agent_version}.tgz")
-      @iso = opts[:iso]
-      @iso_md5 = opts[:iso_md5]
-
-      if @iso
-        unless @iso_md5
-          raise "MD5 must be specified is ISO is specified"
-        end
-        @iso_filename ||= File.basename @iso
-      else
-        init_default_iso
-      end
-    end
-
-    # Merges the given manifest with the default values and assign it to the @manifest instance variable which is later
-    # used to generate the stemcell.MF ( the stemcell manifest) that is put in the generated stemcell archive.
-    def initialize_manifest
-      # perform a deep_merge of the provided manifest with the defaults
-      @manifest = {
-        :name => @name,
-        :version => @agent_version,
-        :bosh_protocol => @bosh_protocol,
-        :cloud_properties => {
-          :root_device_name => DEFAULT_DEVICE_NAME,
-          :infrastructure => @infrastructure,
-          :architecture => @architecture
-        }
-      }
-    end
 
     def sanity_check
       @logger.info "Sanity check"

--- a/lib/stemcell/builders/centos.rb
+++ b/lib/stemcell/builders/centos.rb
@@ -27,9 +27,5 @@ module Bosh::Agent::StemCell
       @iso_filename = "CentOS-6.3-x86_64-minimal.iso"
     end
 
-    def initialize(opts={}, manifest={})
-      super(opts, manifest.deep_merge({:cloud_properties => {:root_device_name => '/dev/sda1'}}))
-    end
-
   end
 end

--- a/lib/stemcell/builders/noop.rb
+++ b/lib/stemcell/builders/noop.rb
@@ -8,9 +8,9 @@ module Bosh::Agent::StemCell
       "noop"
     end
 
-    def initialize(opts={}, manifest={})
+    def initialize(opts)
       @counter = 0
-      super(opts, manifest)
+      super(opts)
     end
 
     def build_vm
@@ -32,7 +32,6 @@ module Bosh::Agent::StemCell
     end
 
     def init_default_iso
-
     end
 
   end

--- a/lib/stemcell/builders/ubuntu.rb
+++ b/lib/stemcell/builders/ubuntu.rb
@@ -27,10 +27,6 @@ module Bosh::Agent::StemCell
       @iso_filename = "ubuntu-11.04-server-amd64.iso"
     end
 
-    def initialize(opts={}, manifest={})
-      super(opts, manifest.deep_merge({:cloud_properties => {:root_device_name => '/dev/sda1'}}))
-    end
-
   end
 
 end

--- a/lib/stemcell/const.rb
+++ b/lib/stemcell/const.rb
@@ -5,6 +5,7 @@ module Bosh
       DEFAULT_STEMCELL_NAME = "bosh-stemcell"
       DEFAULT_INFRASTRUCTURE = "vsphere"
       DEFAULT_ARCHITECTURE = "x86_64"
+      DEFAULT_DEVICE_NAME = "/dev/sda1"
 
     end
   end

--- a/spec/stemcell_builder/builder_spec.rb
+++ b/spec/stemcell_builder/builder_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe Bosh::Agent::StemCell::BaseBuilder do
 
+  include Bosh::Agent::StemCell
+
   class TestBuilder < Bosh::Agent::StemCell::BaseBuilder
     def type
       "noop"
@@ -15,7 +17,7 @@ describe Bosh::Agent::StemCell::BaseBuilder do
     @prefix_dir = Dir.mktmpdir
     @agent_file = File.join(@prefix_dir, "bosh_agent-#{Bosh::Agent::VERSION}.gem")
     FileUtils.touch @agent_file
-    @stemcell = TestBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file}, {})
+    @stemcell = TestBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file})
   end
 
   after(:each) do
@@ -34,7 +36,7 @@ describe Bosh::Agent::StemCell::BaseBuilder do
   end
 
   it "Should initialize all override ISOs properly" do
-    @stemcell = TestBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file, :iso => "http://example.com/example.iso", :iso_md5 => "example-md5", :iso_filename => "example.iso"}, {})
+    @stemcell = TestBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file, :iso => "http://example.com/example.iso", :iso_md5 => "example-md5", :iso_filename => "example.iso"})
     @stemcell.iso.should eq "http://example.com/example.iso"
     @stemcell.iso_md5.should eq "example-md5"
     @stemcell.iso_filename.should eq "example.iso"
@@ -46,6 +48,7 @@ describe Bosh::Agent::StemCell::BaseBuilder do
         :version => Bosh::Agent::VERSION,
         :bosh_protocol => Bosh::Agent::BOSH_PROTOCOL,
         :cloud_properties => {
+            :root_device_name => DEFAULT_DEVICE_NAME,
             :infrastructure => 'vsphere',
             :architecture => 'x86_64'
         }
@@ -53,23 +56,6 @@ describe Bosh::Agent::StemCell::BaseBuilder do
 
     @stemcell.manifest.should eq(defaults)
 
-  end
-
-  it "Initializes the stemcell manifest with defaults and deep_merges the provided args" do
-    manifest = {
-        :name => 'test-stemcell-name',
-        :version => Bosh::Agent::VERSION,
-        :bosh_protocol => Bosh::Agent::BOSH_PROTOCOL,
-        :cloud_properties => {
-            :infrastructure => 'vsphere',
-            :architecture => 'x86_64',
-            :key => 'value'
-        }
-    }
-
-    override_stemcell = TestBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file}, {:name => 'test-stemcell-name',:cloud_properties => {:key => 'value'}})
-
-    override_stemcell.manifest.should eq(manifest)
   end
 
   it "Initializes the options with defaults" do
@@ -80,7 +66,7 @@ describe Bosh::Agent::StemCell::BaseBuilder do
   end
 
   it "Initializes the options with defaults and deep_merges the provided args" do
-    override_stemcell = TestBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file}, {:name => 'test-stemcell-name',:cloud_properties => {:key => 'value'}})
+    override_stemcell = TestBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file})
     override_stemcell.name.should eq "bosh-stemcell"
     override_stemcell.type.should eq "noop"
   end
@@ -119,7 +105,7 @@ describe Bosh::Agent::StemCell::BaseBuilder do
 
   it "Should invoke the methods in the correct order (setup -> build_vm -> package_vm -> finalize)" do
 
-    @stemcell = Bosh::Agent::StemCell::NoOpBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file}, {})
+    @stemcell = Bosh::Agent::StemCell::NoOpBuilder.new({:prefix => @prefix_dir, :agent_src_path => @agent_file})
 
     @stemcell.run # all steps completed properly
 

--- a/spec/stemcell_builder/centos_spec.rb
+++ b/spec/stemcell_builder/centos_spec.rb
@@ -6,7 +6,7 @@ describe Bosh::Agent::StemCell::CentosBuilder do
   before(:each) do
     @agent_file = File.join("bosh-agent.gem")
     FileUtils.touch @agent_file
-    @stemcell = Bosh::Agent::StemCell::CentosBuilder.new({:agent_src_path => @agent_file}, {})
+    @stemcell = Bosh::Agent::StemCell::CentosBuilder.new({:agent_src_path => @agent_file})
   end
 
   after(:each) do

--- a/spec/stemcell_builder/ubuntu_spec.rb
+++ b/spec/stemcell_builder/ubuntu_spec.rb
@@ -6,7 +6,7 @@ describe Bosh::Agent::StemCell::UbuntuBuilder do
   before(:each) do
     @agent_file = File.join("bosh-agent.gem")
     FileUtils.touch @agent_file
-    @stemcell = Bosh::Agent::StemCell::UbuntuBuilder.new({:agent_src_path => @agent_file}, {})
+    @stemcell = Bosh::Agent::StemCell::UbuntuBuilder.new({:agent_src_path => @agent_file})
   end
 
   after(:each) do


### PR DESCRIPTION
I've re-thought about the manifest as initialize parameter. 

The manifest should strictly generated by the options that user input to build the stemcell. User are not allowed to build the stemcell with a set of options, at the same time input another different manifest.

So I remove the manifest. 

So far we use constant DEFAULT_DEVICE_NAME, We could also make it an option when it is needed. 
